### PR TITLE
Fix reading big endian files.

### DIFF
--- a/src/Neurotica/NifTI.m
+++ b/src/Neurotica/NifTI.m
@@ -301,6 +301,8 @@ Protect[$NifTIExtensionCodeCifTI];
    char magic[4] ;      /*!< MUST be "ni1\0" or "n+1\0". */                                       *)
 (* ============================================================================================== *)
 
+flipInteger32Endiannes[k_Integer] := FromDigits[Reverse@IntegerDigits[k, 256, 4], 256]
+
 $NifTI1HeaderSize = 348;
 $NifTI2HeaderSize = 540;
 $MinNifTI1Offset = 352;
@@ -506,8 +508,8 @@ ImportNifTIHeader[stream_, opts___Rule] := Check[
   With[
     {sz = BinaryRead[stream, "Integer32"]},
     Which[
-      sz == $NifTI1HeaderSize, ImportNifTI1Header[stream, opts],
-      sz == $NifTI2HeaderSize, ImportNifTI2Header[stream, opts],
+      sz == $NifTI1HeaderSize || sz == flipInteger32Endiannes[$NifTI1HeaderSize], ImportNifTI1Header[stream, opts],
+      sz == $NifTI2HeaderSize || sz == flipInteger32Endiannes[$NifTI2HeaderSize], ImportNifTI2Header[stream, opts],
       True, Message[ImportNifTI::badfmt, "Header size is invalid!"]]],
   $Failed];
 


### PR DESCRIPTION
Currently Neurotica cannot read big endian files because it always reads the first `Integer32` using the system's default `$ByteOrder` and it expect to get `348` for NifTI-1.  If the system's default byte order differs from the file's, it will instead see `1543569408` and abort with 

> ImportNifTI::badfmt: Bad NifTI file format: Header size is invalid!

This patch fixes that by checking for both possible values.
